### PR TITLE
Store node voltage metrics in memory

### DIFF
--- a/PyDSS/ResultData.py
+++ b/PyDSS/ResultData.py
@@ -28,9 +28,6 @@ from PyDSS.value_storage import ValueContainer, ValueByNumber
 from PyDSS.metrics import OpenDssPropertyMetric, SummedElementsOpenDssPropertyMetric
 
 
-# Flush to disk after this number of steps
-FLUSH_INTERVAL = 1000
-
 logger = logging.getLogger(__name__)
 
 
@@ -55,7 +52,6 @@ class ResultData:
         self._stats = {}
         self._options = options
         self._cur_step = 0
-        self._num_updates = 0
 
         self._dss_command = dss_command
         self._start_day = dss_solver.StartDay
@@ -200,7 +196,6 @@ class ResultData:
 
         self._stats.clear()
         self._stats["Total"] = TimerStats("Total")
-        self._stats["Flusher"] = TimerStats("Flusher")
         base_path = "Exports/" + self._scenario
         for metric in self._iter_metrics():
             metric.initialize_data_store(hdf_store, base_path, num_steps)
@@ -242,12 +237,6 @@ class ResultData:
 
         end = time.time()
         self._stats["Total"].update(end - update_start)
-        self._num_updates += 1
-        if self._num_updates % FLUSH_INTERVAL == 0:
-            start = time.time()
-            self._hdf_store.flush()
-            self._stats["Flusher"].update(time.time() - start)
-            logger.info("Flushed datasets")
 
         self._cur_step += 1
         return current_results

--- a/PyDSS/ResultData.py
+++ b/PyDSS/ResultData.py
@@ -20,8 +20,10 @@ from PyDSS.export_list_reader import ExportListReader, StoreValuesType
 from PyDSS.reports.reports import Reports, ReportGranularity
 from PyDSS.utils.dataframe_utils import write_dataframe
 from PyDSS.utils.utils import dump_data
-from PyDSS.utils.simulation_utils import CircularBufferHelper, TimerStats, \
-    create_datetime_index_from_settings, create_loadshape_pmult_dataframe_for_simulation
+from PyDSS.utils.simulation_utils import (
+    TimerStats, create_datetime_index_from_settings,
+    create_loadshape_pmult_dataframe_for_simulation,
+)
 from PyDSS.value_storage import ValueContainer, ValueByNumber
 from PyDSS.metrics import OpenDssPropertyMetric, SummedElementsOpenDssPropertyMetric
 

--- a/PyDSS/dataset_buffer.py
+++ b/PyDSS/dataset_buffer.py
@@ -162,6 +162,7 @@ class DatasetBuffer:
             dtype,
             max_chunk_bytes=DEFAULT_MAX_CHUNK_BYTES
         ):
+        assert max_size > 0, f"max_size={max_size}"
         tmp = np.empty((1, num_columns), dtype=dtype)
         size_row = tmp.size * tmp.itemsize
         chunk_count = min(int(max_chunk_bytes / size_row), max_size)

--- a/PyDSS/dataset_buffer.py
+++ b/PyDSS/dataset_buffer.py
@@ -38,7 +38,7 @@ class DatasetBuffer:
     def __init__(
             self, hdf_store, path, max_size, dtype, columns, scaleoffset=None,
             max_chunk_bytes=None, attributes=None, names=None,
-            column_ranges_per_name=None
+            column_ranges_per_name=None, data=None
         ):
         if max_chunk_bytes is None:
             max_chunk_bytes = DEFAULT_MAX_CHUNK_BYTES
@@ -46,18 +46,24 @@ class DatasetBuffer:
         self._hdf_store = hdf_store
         self._max_size = max_size
         num_columns = len(columns)
-        self._chunk_size = self.compute_chunk_count(
-            num_columns,
-            max_size,
-            dtype,
-            max_chunk_bytes,
-        )
-        shape = (self._max_size, num_columns)
-        chunks = (self._chunk_size, num_columns)
+        if data is None:
+            self._chunk_size = self.compute_chunk_count(
+                num_columns,
+                max_size,
+                dtype,
+                max_chunk_bytes,
+            )
+            shape = (self._max_size, num_columns)
+            chunks = (self._chunk_size, num_columns)
+        else:
+            self._chunk_size = None
+            shape = None
+            chunks = None
 
         self._dataset = self._hdf_store.create_dataset(
             name=path,
             shape=shape,
+            data=data,
             chunks=chunks,
             dtype=dtype,
             compression="gzip",
@@ -122,6 +128,7 @@ class DatasetBuffer:
         self._buf_index = 0
         self._dataset_index = new_index
         self._dataset.attrs["length"] = new_index
+        self._dataset.flush()
 
     def max_num_bytes(self):
         """Return the maximum number of bytes the container could hold.
@@ -140,6 +147,13 @@ class DatasetBuffer:
         self._buf_index += 1
         if self._buf_index == self._chunk_size:
             self.flush_data()
+
+    def write_data(self, values):
+        """Write the data to the dataset."""
+        new_index = self._dataset_index + len(values)
+        self._dataset[self._dataset_index:new_index] = values
+        self._dataset_index = new_index
+        self._dataset.attrs["length"] = new_index
 
     @staticmethod
     def compute_chunk_count(

--- a/PyDSS/defaults/simulation.toml
+++ b/PyDSS/defaults/simulation.toml
@@ -98,6 +98,7 @@
 "Log to external file" = true
 "Display on screen" = true
 "Clear old log file" = false
+"Log time step updates" = true
 
 [MonteCarlo]
 "Number of Monte Carlo scenarios" = -1

--- a/PyDSS/dssInstance.py
+++ b/PyDSS/dssInstance.py
@@ -19,6 +19,7 @@ import PyDSS.pyPlots as pyPlots
 from PyDSS.dssBus import dssBus
 from PyDSS import SolveMode
 from PyDSS import pyLogger
+from PyDSS.utils.timing_utils import timed_info
 
 import opendssdirect as dss
 import numpy as np
@@ -85,19 +86,7 @@ class OpenDSS:
         for key, path in self._dssPath.items():
             assert (os.path.exists(path)), '{} path: {} does not exist!'.format(key, path)
 
-        self._dssInstance.Basic.ClearAll()
-        self._dssInstance.utils.run_command('Log=NO')
-        run_command('Clear')
-        self._Logger.info('Loading OpenDSS model')
-        try:
-            orig_dir = os.getcwd()
-            reply = run_command('compile ' + self._dssPath['dssFilePath'])
-        finally:
-            os.chdir(orig_dir)
-        self._Logger.info('OpenDSS:  ' + reply)
-
-        if reply != "":
-            raise OpenDssModelError(f"Error compiling OpenDSS model: {reply}")
+        self._CompileModel()
 
         #run_command('Set DefaultBaseFrequency={}'.format(params['Frequency']['Fundamental frequency']))
         self._Logger.info('OpenDSS fundamental frequency set to :  ' + str(params['Frequency']['Fundamental frequency']) + ' Hz')
@@ -153,6 +142,22 @@ class OpenDSS:
                                            self._dssPath)
         self._Logger.info("Simulation initialization complete")
         return
+
+    @timed_info
+    def _CompileModel(self):
+        self._dssInstance.Basic.ClearAll()
+        self._dssInstance.utils.run_command('Log=NO')
+        run_command('Clear')
+        self._Logger.info('Loading OpenDSS model')
+        try:
+            orig_dir = os.getcwd()
+            reply = run_command('compile ' + self._dssPath['dssFilePath'])
+        finally:
+            os.chdir(orig_dir)
+
+        self._Logger.info('OpenDSS:  ' + reply)
+        if reply != "":
+            raise OpenDssModelError(f"Error compiling OpenDSS model: {reply}")
 
     def _ModifyNetwork(self):
         # self._Modifier.Add_Elements('Storage', {'bus' : ['storagebus'], 'kWRated' : ['2000'], 'kWhRated'  : ['2000']},

--- a/PyDSS/dssInstance.py
+++ b/PyDSS/dssInstance.py
@@ -452,7 +452,7 @@ class OpenDSS:
                 # with any data in memory.
                 self.ResultContainer.Close()
 
-            for postprocessor in postprocessors: 
+            for postprocessor in postprocessors:
                 postprocessor.finalize()
 
         if self._Options and self._Options['Exports']['Log Results']:

--- a/PyDSS/dssInstance.py
+++ b/PyDSS/dssInstance.py
@@ -297,9 +297,9 @@ class OpenDSS:
 
     def RunStep(self, step, updateObjects=None):
         # updating parameters bebore simulation run
-        time_step_has_converged = True
-        self._Logger.info(f'PyDSS datetime - {self._dssSolver.GetDateTime()}')
-        self._Logger.info(f'OpenDSS time [h] - {self._dssSolver.GetOpenDSSTime()}')
+        if self._Options["Logging"]["Log time step updates"]:
+            self._Logger.info(f'PyDSS datetime - {self._dssSolver.GetDateTime()}')
+            self._Logger.info(f'OpenDSS time [h] - {self._dssSolver.GetOpenDSSTime()}')
         if self._Options['Profiles']["Use profile manager"]:
             self.profileStore.update()
 
@@ -312,6 +312,7 @@ class OpenDSS:
                     self._Modifier.Edit_Element(cl, name, params)
 
         # run simulation time step and get results
+        time_step_has_converged = True
         if not self._Options['Project']['Disable PyDSS controllers']:
             for priority in range(CONTROLLER_PRIORITIES):
                 priority_has_converged = False

--- a/PyDSS/modes/Snapshot.py
+++ b/PyDSS/modes/Snapshot.py
@@ -11,6 +11,9 @@ class Snapshot(solver_base):
     def reSolve(self):
         return self._dssSolution.SolveNoControl()
 
+    def SimulationSteps(self):
+        return 1, self._StartTime, self._EndTime
+
     def Solve(self):
         self._dssSolution.Solve()
 

--- a/PyDSS/node_voltage_metrics.py
+++ b/PyDSS/node_voltage_metrics.py
@@ -1,0 +1,384 @@
+from datetime import datetime, timedelta
+from pathlib import Path
+from typing import Dict, List
+
+from pydantic import BaseModel, Field
+
+from PyDSS.utils.simulation_utils import CircularBufferHelper
+
+
+class VoltageMetricsBaseModel(BaseModel):
+    class Config:
+        title = "VoltageMetricsBaseModel"
+        anystr_strip_whitespace = True
+        validate_assignment = True
+        validate_all = True
+        extra = "forbid"
+        use_enum_values = False
+
+
+class VoltageMetric1(VoltageMetricsBaseModel):
+    time_points: List[datetime] = Field(
+        title="time_points",
+        description="time points that contain voltages between ANSI A and ANSI B thresholds",
+    )
+    duration: timedelta = Field(
+        title="duration",
+        description="amount of time where metric 1 existed (len(time_points) * resolution)",
+    )
+
+
+class VoltageMetric2(VoltageMetricsBaseModel):
+    duration: timedelta = Field(
+        title="duration",
+        description="amount of time where a node experienced ANSI A violations",
+    )
+    duration_percentage: float = Field(
+        title="duration_percentage",
+        description="percentage of overall time",
+    )
+
+
+class VoltageMetric3(VoltageMetricsBaseModel):
+    time_points: List[datetime] = Field(
+        title="time_points",
+        description="time points where moving average voltages violated ANSI A thresholds",
+    )
+    duration: timedelta = Field(
+        title="duration",
+        description="amount of time where metric 2 existed (len(time_points) * resolution)",
+    )
+
+
+class VoltageMetric4(VoltageMetricsBaseModel):
+    percent_node_ansi_a_violations: List[List] = Field(
+        title="percent_node_ansi_a_violations",
+        description="percent of nodes with ANSI A violations at time points. Excludes time "
+        "points with no violations. Inner list is [timestamp, percent].",
+    )
+
+
+class VoltageMetric5(VoltageMetricsBaseModel):
+    min_voltages: Dict = Field(
+        title="min_voltage_by_node",
+        description="Mapping of node name to minimum voltage",
+    )
+    max_voltages: Dict = Field(
+        title="max_voltage_by_node",
+        description="Mapping of node name to maximum voltage",
+    )
+
+
+class VoltageMetric6(VoltageMetricsBaseModel):
+    num_time_points: int = Field(
+        title="num_time_points",
+        description="number of time points that violate ANSI B thresholds",
+    )
+    percent_time_points: float = Field(
+        title="percent_time_points",
+        description="percentage of time points that violate ANSI B thresholds",
+    )
+    duration: timedelta = Field(
+        title="duration",
+        description="amount of time where metric 6 existed (len(num_time_points) * resolution)",
+    )
+
+
+class VoltageMetricsSummaryModel(VoltageMetricsBaseModel):
+    voltage_duration_between_ansi_a_and_b_minutes: int = Field(
+        title="voltage_duration_between_ansi_a_and_b_minutes",
+        description="time in minutes that contain voltages between ANSI A and ANSI B thresholds",
+    )
+    max_per_node_voltage_duration_outside_ansi_a_minutes: float = Field(
+        title="max_per_node_voltage_duration_outside_ansi_a_minutes",
+        description="maximum time in minutes that a node was outside ANSI A thresholds",
+    )
+    moving_average_voltage_duration_outside_ansi_a_minutes: float = Field(
+        title="moving_average_voltage_duration_outside_ansi_a_minutes",
+        description="time in minutes the moving average voltage was outside ANSI A",
+    )
+    moving_window_minutes: int = Field(
+        title="moving_window_minutes",
+        description="window size in minutes for moving average metrics",
+    )
+    max_voltage: float = Field(
+        title="max_voltage",
+        description="maximum voltage seen on any node",
+    )
+    min_voltage: float = Field(
+        title="min_voltage",
+        description="minimum voltage seen on any node",
+    )
+    num_nodes_always_inside_ansi_a: int = Field(
+        title="num_nodes_always_inside_ansi_a",
+        description="number of nodes always inside ANSI A thresholds",
+    )
+    num_nodes_any_outside_ansi_a_always_inside_ansi_b: int = Field(
+        title="num_nodes_any_outside_ansi_a_always_inside_ansi_b",
+        description="number of nodes with some ANSI A violations but no ANSI B violations",
+    )
+    num_nodes_any_outside_ansi_b: int = Field(
+        title="num_nodes_always_outside_ansi_b",
+        description="number of nodes with some ANSI B violations",
+    )
+    num_time_points_with_ansi_b_violations: int = Field(
+        title="num_time_points_with_ansi_b_violations",
+        description="number of time points with ANSI B violations",
+    )
+    total_num_time_points: int = Field(
+        title="total_num_time_points",
+        description="number of time points in the simulation",
+    )
+    total_simulation_duration: timedelta = Field(
+        title="total_simulation_duration",
+        description="total length of time of the simulation",
+    )
+
+
+class VoltageMetricsModel(VoltageMetricsBaseModel):
+    metric_1: VoltageMetric1 = Field(
+        title="metric_1",
+        description="metric 1",
+    )
+    metric_2: Dict[str, VoltageMetric2] = Field(
+        title="metric_2",
+        description="metric 2",
+    )
+    metric_3: VoltageMetric3 = Field(
+        title="metric_3",
+        description="metric 3",
+    )
+    metric_4: VoltageMetric4 = Field(
+        title="metric_4",
+        description="metric 4",
+    )
+    metric_5: VoltageMetric5 = Field(
+        title="metric_5",
+        description="metric 5",
+    )
+    metric_6: VoltageMetric6 = Field(
+        title="metric_6",
+        description="metric 6",
+    )
+    summary: VoltageMetricsSummaryModel = Field(
+        title="summary",
+        description="summary of metrics",
+    )
+
+
+class SimulationVoltageMetricsModel(VoltageMetricsBaseModel):
+    scenarios: Dict[str, VoltageMetricsModel] = Field(
+        title="scenarios",
+        description="voltage metrics by PyDSS scenario name",
+    )
+
+
+class NodeVoltageMetrics:
+    """Stores node voltage metrics in memory.
+
+    The metrics are defined in this paper:
+    https://www.sciencedirect.com/science/article/pii/S0306261920311351
+
+    """
+
+    FILENAME = "voltage_metrics.json"
+
+    def __init__(self, prop, start_time, resolution, window_size):
+        self._start_time = start_time
+        self._resolution = resolution
+        self._range_a_limits = prop.limits
+        self._range_b_limits = prop.limits_b
+        self._window_size = window_size
+        self._node_names = None
+        self._metric_1_time_steps = []
+        self._metric_2_violation_counts = []
+        self._metric_3_time_steps = []
+        self._metric_4_violations = []
+        self._metric_5_min_violations = []
+        self._metric_5_max_violations = []
+        self._metric_6_time_points_outside_range_b = 0
+        self._bufs = None
+        self._num_time_points = 0
+
+    def _create_summary(self, metric_1, metric_2, metric_3, metric_5, metric_6):
+        moving_window_minutes = int(
+            (self._window_size * self._resolution).total_seconds() / 60
+        )
+        max_pnvdoaa = max((x.duration for x in metric_2.values())).total_seconds()
+        vdbaab = metric_1.duration.total_seconds()
+        mmavdoa = metric_3.duration.total_seconds()
+        max_voltage_overall = max(metric_5.max_voltages.values())
+        min_voltage_overall = min(metric_5.min_voltages.values())
+
+        num_nodes_always_inside_range_a = 0
+        num_nodes_any_outside_range_a_no_b = 0
+        num_nodes_any_outside_range_b = 0
+        for node in self._node_names:
+            min_voltage = metric_5.min_voltages[node]
+            max_voltage = metric_5.max_voltages[node]
+            if (
+                min_voltage < self._range_b_limits.min
+                or max_voltage > self._range_b_limits.max
+            ):
+                num_nodes_any_outside_range_b += 1
+            elif (
+                min_voltage < self._range_a_limits.min
+                or max_voltage > self._range_a_limits.max
+            ):
+                num_nodes_any_outside_range_a_no_b += 1
+            else:
+                num_nodes_always_inside_range_a += 1
+
+        return VoltageMetricsSummaryModel(
+            voltage_duration_between_ansi_a_and_b_minutes=vdbaab / 60,
+            max_per_node_voltage_duration_outside_ansi_a_minutes=max_pnvdoaa / 60,
+            moving_average_voltage_duration_outside_ansi_a_minutes=mmavdoa / 60,
+            moving_window_minutes=moving_window_minutes,
+            max_voltage=max_voltage_overall,
+            min_voltage=min_voltage_overall,
+            num_nodes_always_inside_ansi_a=num_nodes_always_inside_range_a,
+            num_nodes_any_outside_ansi_a_always_inside_ansi_b=num_nodes_any_outside_range_a_no_b,
+            num_nodes_any_outside_ansi_b=num_nodes_any_outside_range_b,
+            num_time_points_with_ansi_b_violations=metric_6.num_time_points,
+            total_num_time_points=self._num_time_points,
+            total_simulation_duration=self._num_time_points * self._resolution,
+        )
+
+    def _is_outside_range_a(self, value):
+        return value < self._range_a_limits.min or value > self._range_a_limits.max
+
+    def _is_outside_range_b(self, value):
+        return value < self._range_b_limits.min or value > self._range_b_limits.max
+
+    def generate_report(self, path):
+        """Create a summary file containing all metrics.
+
+        Parameters
+        ----------
+        path : str
+
+        Returns
+        -------
+        str
+            report filename
+
+        """
+        metric_1 = VoltageMetric1(
+            time_points=self._metric_1_time_steps,
+            duration=len(self._metric_1_time_steps) * self._resolution,
+        )
+        metric_2 = {
+            self._node_names[i]: VoltageMetric2(
+                duration=x * self._resolution,
+                duration_percentage=x / self._num_time_points * 100,
+            )
+            for i, x in enumerate(self._metric_2_violation_counts)
+        }
+        metric_3 = VoltageMetric3(
+            time_points=self._metric_3_time_steps,
+            duration=len(self._metric_3_time_steps) * self._resolution,
+        )
+        metric_4 = VoltageMetric4(
+            percent_node_ansi_a_violations=self._metric_4_violations,
+        )
+        metric_5 = VoltageMetric5(
+            min_voltages={
+                self._node_names[i]: x
+                for i, x in enumerate(self._metric_5_min_violations)
+            },
+            max_voltages={
+                self._node_names[i]: x
+                for i, x in enumerate(self._metric_5_max_violations)
+            },
+        )
+        metric_6 = VoltageMetric6(
+            num_time_points=self._metric_6_time_points_outside_range_b,
+            percent_time_points=self._metric_6_time_points_outside_range_b
+            / self._num_time_points
+            * 100,
+            duration=self._metric_6_time_points_outside_range_b * self._resolution,
+        )
+        metrics = VoltageMetricsModel(
+            metric_1=metric_1,
+            metric_2=metric_2,
+            metric_3=metric_3,
+            metric_4=metric_4,
+            metric_5=metric_5,
+            metric_6=metric_6,
+            summary=self._create_summary(
+                metric_1, metric_2, metric_3, metric_5, metric_6
+            ),
+        )
+
+        filename = Path(path) / self.FILENAME
+        with open(filename, "w") as f_out:
+            f_out.write(metrics.json())
+            f_out.write("\n")
+
+    @property
+    def node_names(self):
+        return self._node_names
+
+    @node_names.setter
+    def node_names(self, names):
+        self._node_names = names
+
+    def increment_steps(self):
+        """Increment the time step counter."""
+        self._num_time_points += 1
+
+    def update(self, time_step, voltages):
+        """Update the metrics for the time step.
+
+        Parameters
+        ----------
+        time_step : int
+        voltages : list
+            list of ValueStorageBase
+
+        """
+        cur_time = self._start_time + self._resolution * time_step
+        if self._bufs is None:
+            self._bufs = [CircularBufferHelper(self._window_size)] * len(
+                self._node_names
+            )
+            self._metric_2_violation_counts = [0] * len(self._node_names)
+            self._metric_5_min_violations = [None] * len(self._node_names)
+            self._metric_5_max_violations = [None] * len(self._node_names)
+
+        count_outside_range_a = 0
+        any_outside_range_b = False
+        any_moving_avg_violates_range_a = False
+        for i, voltage in enumerate(voltages):
+            buf = self._bufs[i]
+            buf.append(voltage.value)
+            if not any_moving_avg_violates_range_a and self._is_outside_range_a(
+                buf.average()
+            ):
+                any_moving_avg_violates_range_a = True
+
+            if self._is_outside_range_a(voltage.value):
+                count_outside_range_a += 1
+                self._metric_2_violation_counts[i] += 1
+            if self._is_outside_range_b(voltage.value):
+                any_outside_range_b = True
+            if self._metric_5_min_violations[i] is None:
+                self._metric_5_min_violations[i] = voltage.value
+                self._metric_5_max_violations[i] = voltage.value
+            elif voltage.value < self._metric_5_min_violations[i]:
+                self._metric_5_min_violations[i] = voltage.value
+            elif voltage.value > self._metric_5_max_violations[i]:
+                self._metric_5_max_violations[i] = voltage.value
+
+        if count_outside_range_a > 0:
+            if not any_outside_range_b:
+                self._metric_1_time_steps.append(cur_time)
+
+            percent_violations = count_outside_range_a / len(self._node_names) * 100
+            self._metric_4_violations.append((cur_time, percent_violations))
+
+        if any_moving_avg_violates_range_a:
+            self._metric_3_time_steps.append(cur_time)
+
+        if any_outside_range_b:
+            self._metric_6_time_points_outside_range_b += 1

--- a/PyDSS/node_voltage_metrics.py
+++ b/PyDSS/node_voltage_metrics.py
@@ -46,7 +46,7 @@ class VoltageMetric3(VoltageMetricsBaseModel):
     )
     duration: timedelta = Field(
         title="duration",
-        description="amount of time where metric 2 existed (len(time_points) * resolution)",
+        description="amount of time where metric 3 existed (len(time_points) * resolution)",
     )
 
 
@@ -196,7 +196,7 @@ class NodeVoltageMetrics:
         self._metric_4_violations = []
         self._metric_5_min_violations = []
         self._metric_5_max_violations = []
-        self._metric_6_time_points_outside_range_b = 0
+        self._num_metric_6_time_points_outside_range_b = 0
         self._bufs = None
         self._num_time_points = 0
 
@@ -292,11 +292,11 @@ class NodeVoltageMetrics:
             },
         )
         metric_6 = VoltageMetric6(
-            num_time_points=self._metric_6_time_points_outside_range_b,
-            percent_time_points=self._metric_6_time_points_outside_range_b
+            num_time_points=self._num_metric_6_time_points_outside_range_b,
+            percent_time_points=self._num_metric_6_time_points_outside_range_b
             / self._num_time_points
             * 100,
-            duration=self._metric_6_time_points_outside_range_b * self._resolution,
+            duration=self._num_metric_6_time_points_outside_range_b * self._resolution,
         )
         metrics = VoltageMetricsModel(
             metric_1=metric_1,
@@ -381,4 +381,4 @@ class NodeVoltageMetrics:
             self._metric_3_time_steps.append(cur_time)
 
         if any_outside_range_b:
-            self._metric_6_time_points_outside_range_b += 1
+            self._num_metric_6_time_points_outside_range_b += 1

--- a/PyDSS/reports/feeder_losses.py
+++ b/PyDSS/reports/feeder_losses.py
@@ -21,7 +21,8 @@ class FeederLossesReport(ReportBase):
 
     def generate(self, output_dir):
         assert len(self._results.scenarios) == 2
-        scenario = self._results.scenarios[1]
+        scenario = self._results.scenarios[0]
+        assert scenario.name == "control_mode"
         total_losses_dict = scenario.get_summed_element_total("Circuits", "LossesSum")
         total_losses = abs(next(iter(total_losses_dict.values())))
         line_losses_dict = scenario.get_summed_element_total("Circuits", "LineLossesSum")
@@ -71,4 +72,4 @@ class FeederLossesReport(ReportBase):
 
     @staticmethod
     def get_required_scenario_names():
-        return set()
+        return set(["control_mode"])

--- a/PyDSS/reports/pv_reports.py
+++ b/PyDSS/reports/pv_reports.py
@@ -25,8 +25,9 @@ class PvReportBase(ReportBase, abc.ABC):
     def __init__(self, name, results, simulation_config):
         super().__init__(name, results, simulation_config)
         assert len(results.scenarios) == 2
-        self._pf1_scenario = results.scenarios[0]
-        self._control_mode_scenario = results.scenarios[1]
+        self._control_mode_scenario = results.scenarios[0]
+        assert self._control_mode_scenario.name == "control_mode"
+        self._pf1_scenario = results.scenarios[1]
         cm_profiles = self._control_mode_scenario.read_pv_profiles()
         if not cm_profiles:
             self._pv_system_names = []

--- a/PyDSS/reports/voltage_metrics.py
+++ b/PyDSS/reports/voltage_metrics.py
@@ -1,6 +1,7 @@
-
+import os
 from collections import defaultdict
 from datetime import timedelta
+from pathlib import Path
 import logging
 
 import pandas as pd
@@ -8,7 +9,11 @@ import pandas as pd
 from PyDSS.common import StoreValuesType
 from PyDSS.exceptions import InvalidConfiguration
 from PyDSS.reports.reports import ReportBase, ReportGranularity
-from PyDSS.utils.utils import serialize_timedelta, deserialize_timedelta
+from PyDSS.utils.utils import serialize_timedelta, deserialize_timedelta, load_data
+from PyDSS.node_voltage_metrics import (
+    SimulationVoltageMetricsModel,
+    VoltageMetricsModel,
+)
 
 
 logger = logging.getLogger(__name__)
@@ -50,6 +55,7 @@ class VoltageMetrics(ReportBase):
             # If necessary, convert to a moving average with pandas.
 
     """
+
     DEFAULTS = {
         "range_a_limits": [0.95, 1.05],
         "range_b_limits": [0.90, 1.0583],
@@ -61,378 +67,56 @@ class VoltageMetrics(ReportBase):
     def __init__(self, name, results, simulation_config):
         super().__init__(name, results, simulation_config)
         assert len(results.scenarios) == 2
-        self._granularity = ReportGranularity(self._report_global_options["Granularity"])
+        self._granularity = ReportGranularity(
+            self._report_global_options["Granularity"]
+        )
         self._range_a_limits = self._report_options["range_a_limits"]
         self._range_b_limits = self._report_options["range_b_limits"]
         self._resolution = self._get_simulation_resolution()
-        inputs = self.get_inputs_from_defaults(self._simulation_config, self.NAME)
-        
-        self._window_size = int(
-            timedelta(minutes=inputs["window_size_minutes"]) / self._resolution
-        )
-        
-        self._store_type = self._get_store_type(inputs, self._resolution)
-        self._prop_name = "VoltageMetric"
-        if self._store_type == StoreValuesType.MOVING_AVERAGE:
-            self._prop_name += "Avg"
-        node_names1 = self._scenarios[0].list_element_names("Nodes", self._prop_name)
-        node_names2 = self._scenarios[1].list_element_names("Nodes", self._prop_name)
-        assert len(node_names1) == len(node_names2)
-        self._node_names = node_names1
 
     def generate(self, output_dir):
-        data = {
-            "scenarios": [x.name for x in self._results.scenarios],
-            "num_nodes": len(self._node_names),
-            "metric_1": {},
-            "metric_2": {},
-            "metric_3": {},
-            "metric_4": [],
-            "metric_5": {},
-            "metric_6": {},
-            "summary": {},
-        }
-        dfs = {
-            x.name: x.get_filtered_dataframes("Nodes", self._prop_name)
-            for x in self._results.scenarios
-        }
+        # The generation code in this file has been deprecated in favor of the in-memory
+        # collection in PyDSS/node_voltage_metrics.
+        # Keeping this code around in case we want to make the behavior configurable.
+        # The old code stores all violations, which could be useful.
+        # data["summary"] = self._sumarize_metrics(data)
+
+        metrics = {}
         for scenario in self._results.scenarios:
-            name = scenario.name
-            
-            data["metric_1"][name] = self._gen_metric_1(name, dfs[name])
-            data["metric_2"][name], output = self._gen_metric_4(name, dfs[name], output_dir)
-            data["metric_3"][name] = self._gen_metric_3(name, dfs[name])
-            data["metric_4"].append(output)
-            data["metric_5"][name] = self._gen_metric_5(scenario, dfs[name])
-        data["metric_6"] = self._gen_metric_6(dfs)
-        
-        data["summary"] = self._sumarize_metrics(data)
-
-        # Note: metric 3 has to be read from the raw data. It is not duplicated
-        # in the Reports directory.
-        self._export_json_report(data, output_dir, self.FILENAME)
-
-    def _gen_metric_1(self, name, dfs):
-        # This metric determines the total time points when any nodal voltage
-        # in the feeder violates ANSI Range A voltage limits but all nodes in
-        # the feeder are within ANSI Range B limits.
-        dur = timedelta(0)
-        results = {
-            "time_points": [],
-            "duration": serialize_timedelta(dur)
-        }
-        if not dfs:
-            return results
-
-        
-        total_a = None
-        total_b = None
-        for df in dfs.values():
-            series_a = df.applymap(self._one_if_violates_range_a_within_b).iloc[:, 0]
-            series_b = df.applymap(self._one_if_violates_range_b).iloc[:, 0]
-            if total_a is None:
-                total_a = series_a
-                total_b = series_b
-            else:
-                total_a = total_a.add(series_a, fill_value=0)
-                total_b = total_b.add(series_b, fill_value=0)
-        results["time_points"] = [
-            str(ts) for ts, val in total_a.iteritems() if val > 0 and total_b.loc[ts] == 0
-        ]
-        results["duration"] = str(len(results["time_points"]) * self._resolution)
-        dur = len(results["time_points"]) * self._resolution
-        results["duration"] = serialize_timedelta(dur)
-        return results
-    
-    def _gen_metric_3(self, name, dfs):
-        # This metric determines the total time points when any nodal moving average voltage
-        # in the feeder violates ANSI Range A voltage limits.
-        dur = timedelta(0)
-        results = {
-            "time_points": [],
-            "duration": serialize_timedelta(dur)
-        }
-        if not dfs:
-            return results
-        
-        total_a = None
-        
-        for df in dfs.values():
-            df = df.rolling(self._window_size).mean()
-            series_a = df.applymap(self._one_if_violates_range_a).iloc[:, 0]
-            if total_a is None:
-                total_a = series_a
-                
-            else:
-                total_a = total_a.add(series_a, fill_value=0)
-                
-        results["time_points"] = [
-            str(ts) for ts, val in total_a.iteritems() if val > 0 
-        ]
-        dur = len(results["time_points"]) * self._resolution
-        results["duration"] = serialize_timedelta(dur)
-        
-        return results
-    
-    
-
-    def _gen_metric_4(self, scenario_name, dfs, output_dir):
-        # Create a dataframe whose single column is a percentage of the number
-        # of nodes experiencing violations at each time point.
-        # Time points with no violations are not present in the dataframe.
-
-        # Also create a dictionary of node name to range A violation count for
-        # use in Metric 2.
-
-        # FUTURE: need to have a metric showing consecutive periods of violations.
-        # Perhaps this could be the longest continuous range of violations for each node.
-        node_violations = {}
-        total = None
-        num_steps = self._get_num_steps()
-        for node_name, df in dfs.items():
-            series = df.applymap(self._one_if_violates_range_a).iloc[:, 0]
-            count = series.sum()
-            dur = count * self._resolution
-            node_violations[node_name] = {"duration": {}, "percentage": {}}
-            node_violations[node_name]["duration"] = serialize_timedelta(dur)
-            node_violations[node_name]["percentage"] = float(count / num_steps) * 100
-            if total is None:
-                total = series
-            else:
-                total = total.add(series, fill_value=0)
-
-        if total is None:
-            df = pd.DataFrame()
-        else:
-            total = total / len(self._node_names) * 100
-            total.name = "Percent Node Violations Range A"
-            df = pd.DataFrame(total)
-
-        basename = f"voltage_metric_4__{scenario_name}"
-        filename = self._export_dataframe_report(df, output_dir, basename)
-        return node_violations, filename
-
-    def _one_if_violates_range_a(self, val):
-        return self._one_if_violates_limits(val, self._range_a_limits)
-
-    def _one_if_violates_range_b(self, val):
-        return self._one_if_violates_limits(val, self._range_b_limits)
-
-    @staticmethod
-    def _one_if_violates_limits(val, limits):
-        return 1 if (val < limits[0] or val > limits[1]) else 0
-
-    def _one_if_violates_range_a_within_b(self, val):
-        limits_a = self._range_a_limits
-        limits_b = self._range_b_limits
-        if (val < limits_a[0] and val > limits_b[0]) or (val > limits_a[1] and val < limits_b[1]):
-            return 1
-        return 0
-
-    def _gen_metric_5(self, scenario, dfs):
-        if self._store_type == StoreValuesType.ALL:
-            return self._gen_metric_5_all(dfs)
-        return self._gen_metric_5_min_max(scenario)
-
-    def _gen_metric_5_all(self, dfs):
-        # Check the max and min voltages against the ANSI ranges.
-        node_voltages = defaultdict(dict)
-        num_outside_range_b = 0
-        num_between_ranges = 0
-        num_inside_range_a = 0
-        overall_max = None
-        overall_min = None
-        for name, df in dfs.items():
-            max_val = df.iloc[:, 0].max()
-            min_val = df.iloc[:, 0].min()
-            if min_val < self._range_b_limits[0] or max_val > self._range_b_limits[1]:
-                num_outside_range_b += 1
-            elif min_val < self._range_a_limits[0] or max_val > self._range_a_limits[1]:
-                num_between_ranges += 1
-            else:
-                num_inside_range_a += 1
-            overall_max, overall_min = self._get_new_max_min(
-                node_voltages, name, max_val, min_val, overall_max, overall_min
+            filename = os.path.join(
+                self._simulation_config["Project"]["Project Path"],
+                self._simulation_config["Project"]["Active Project"],
+                "Exports",
+                scenario.name,
+                self.FILENAME,
             )
+            metrics[scenario.name] = VoltageMetricsModel(**load_data(filename))
 
-        return {
-            "max_min_node_voltages": node_voltages,
-            "num_outside_range_b": num_outside_range_b,
-            "num_between_ranges": num_between_ranges,
-            "num_inside_range_a": num_inside_range_a,
-            "max_voltage": overall_max,
-            "min_voltage": overall_min,
-        }
+        model = SimulationVoltageMetricsModel(scenarios=metrics)
 
-    def _gen_metric_5_min_max(self, scenario):
-        overall_max = None
-        overall_min = None
-        node_voltages = defaultdict(dict)
-        for name in scenario.list_element_value_names("Nodes", "VoltageMetricMin"):
-            max_val = scenario.get_element_property_value("Nodes", "VoltageMetricMax", name)
-            min_val = scenario.get_element_property_value("Nodes", "VoltageMetricMin", name)
-            overall_max, overall_min = self._get_new_max_min(
-                node_voltages, name, max_val, min_val, overall_max, overall_min
-            )
+        filename = os.path.join(output_dir, self.FILENAME)
+        with open(filename, "w") as f_out:
+            f_out.write(model.json())
+            f_out.write("\n")
 
-        return {
-            "max_min_node_voltages": node_voltages,
-            "max_voltage": overall_max,
-            "min_voltage": overall_min,
-            # TODO: these are not implemented for this mode
-            "num_outside_range_b": None,
-            "num_between_ranges": None,
-            "num_inside_range_a": None,
-        }
+        logger.info("Generated %s", filename)
 
-    @staticmethod
-    def _get_new_max_min(node_voltages, name, max_val, min_val, overall_max, overall_min):
-        node_voltages[name]["max"] = max_val
-        node_voltages[name]["min"] = min_val
-        if overall_max is None:
-            overall_max = max_val
-            overall_min = min_val
-        else:
-            if max_val > overall_max:
-                overall_max = max_val
-            if min_val < overall_min:
-                overall_min = min_val
-        return overall_max, overall_min
-
-    def _gen_metric_6(self, dfs):
-        pf1_time_points = self._gen_metric_6_violation_time_points(
-            dfs[self._results.scenarios[0].name],
-            self._results.scenarios[0],
-        )
-        cm_time_points = self._gen_metric_6_violation_time_points(
-            dfs[self._results.scenarios[1].name],
-            self._results.scenarios[1],
-        )
-        return {
-            "num_time_points_violations_pf1": len(pf1_time_points),
-            "num_time_points_violations_control_mode": len(cm_time_points),
-        }
-
-    def _gen_metric_6_violation_time_points(self, dfs, scenario):
-        # Record number of time points with range B violations and compare to
-        # baseline.
-        violation_time_points = set()
-        for df in dfs.values():
-            violation_time_points.update(set(df.index.values))
-        return violation_time_points
-
-    def _sumarize_metrics(self, data, scenario='control_mode'):
-        
-        voltage_metric_summary = {}
-        num_time_points = self._get_num_steps()
-        tot_dur = num_time_points * self._resolution
-        moving_window_minutes = int(
-            (self._window_size * self._resolution).total_seconds() / 60
-        )
-        
-        if scenario in data['scenarios']:
-            if data['metric_2'][scenario].values():
-                max_pnvdoaa = max([x['duration'] for x in data['metric_2'][scenario].values()])
-                max_pnvdoaa = deserialize_timedelta(max_pnvdoaa).total_seconds()
-            else:
-                max_pnvdoaa = 0
-            
-            vdbaab = deserialize_timedelta(data['metric_1'][scenario]['duration']).total_seconds()
-            mmavdoa = deserialize_timedelta(data['metric_3'][scenario]['duration']).total_seconds()
-            
-            maxv = data['metric_5'][scenario]['max_voltage']
-            
-            if maxv is None:
-                maxv = self._range_a_limits[1]
-                
-            minv = data['metric_5'][scenario]['min_voltage']
-            if minv is None:
-                minv = self._range_a_limits[1]
-                
-            voltage_metric_summary = {
-                'voltage_duration_between_ansi_a_and_b-minutes': vdbaab / 60,
-                'max_per_node_voltage_duration_outside_ansi_a-minutes': max_pnvdoaa / 60,
-                 f'{moving_window_minutes}-minute_moving_average_voltage_duration_outside_ansi_a-minutes': mmavdoa / 60,
-                'max_voltage': maxv,
-                'min_voltage': minv,
-                'num_nodes_always_inside_ansi_a': data['metric_5'][scenario]['num_inside_range_a'],
-                'num_nodes_always_between_ansi_a_and_b': data['metric_5'][scenario]['num_between_ranges'],
-                'num_nodes_always_outside_ansi_b': data['metric_5'][scenario]['num_outside_range_b'],
-                'num_time_points_with_ansi_a_violations': data['metric_6'][f'num_time_points_violations_{scenario}'],
-                'total_num_time_points': num_time_points,
-                'total_simulation_duration': serialize_timedelta(tot_dur)
-            }
-            
-        return voltage_metric_summary
-        
     @staticmethod
     def get_required_exports(simulation_config):
-        resolution = timedelta(seconds=simulation_config["Project"]["Step resolution (sec)"])
-        inputs = VoltageMetrics.get_inputs_from_defaults(simulation_config, VoltageMetrics.NAME)
-        if inputs.get("force_instantaneous", False):
-            data = VoltageMetrics._get_required_exports_instantaneous(inputs)
-        elif inputs.get("force_moving_average", False):
-            data = VoltageMetrics._get_required_exports_moving_average(inputs, resolution)
-        elif resolution >= timedelta(minutes=15):
-            data = VoltageMetrics._get_required_exports_instantaneous(inputs)
-        else:
-            data = VoltageMetrics._get_required_exports_moving_average(inputs, resolution)
-
-        return data
-
-    @staticmethod
-    def get_required_scenario_names():
-        return set(["control_mode"])
-
-    @staticmethod
-    def _get_required_exports_instantaneous(inputs):
+        inputs = VoltageMetrics.get_inputs_from_defaults(
+            simulation_config, VoltageMetrics.NAME
+        )
         return {
             "Nodes": [
                 {
                     "property": "VoltageMetric",
                     "store_values_type": "all",
                     "limits": inputs["range_a_limits"],
+                    "limits_b": inputs["range_b_limits"],
                 },
             ]
         }
 
     @staticmethod
-    def _get_required_exports_moving_average(inputs, resolution):
-        window_size_td = timedelta(minutes=inputs["window_size_minutes"])
-        if window_size_td % resolution != timedelta(0):
-            raise InvalidConfiguration(
-                f"window_size_minutes={window_size_td} must be a multiple of {resolution}"
-            )
-        window_size = int(window_size_td / resolution)
-
-        return {
-            "Nodes": [
-                {
-                    "property": "VoltageMetric",
-                    "store_values_type": "moving_average",
-                    "limits": inputs["range_a_limits"],
-                    "window_size": window_size,
-                },
-                {
-                    "property": "VoltageMetric",
-                    "store_values_type": "max",
-                },
-                {
-                    "property": "VoltageMetric",
-                    "store_values_type": "min",
-                }
-            ]
-        }
-
-    @staticmethod
-    def _get_store_type(inputs, resolution):
-        if inputs.get("force_instantaneous", False):
-            val = StoreValuesType.ALL
-        elif inputs.get("force_moving_average", False):
-            val = StoreValuesType.MOVING_AVERAGE
-        elif resolution >= timedelta(minutes=15):
-            val = StoreValuesType.ALL
-        else:
-            val = StoreValuesType.MOVING_AVERAGE
-
-        return val
+    def get_required_scenario_names():
+        return set(["control_mode"])

--- a/PyDSS/utils/simulation_utils.py
+++ b/PyDSS/utils/simulation_utils.py
@@ -82,6 +82,38 @@ class TimerStats:
             self._min = duration
 
 
+def get_start_time(settings):
+    """Return the start time of the simulation.
+
+    Parameters
+    ----------
+    settings : dict
+        settings from project simulation.toml
+
+    Returns
+    -------
+    datetime
+
+    """
+    return datetime.strptime(settings['Project']["Start time"], DATE_FORMAT)
+
+
+def get_simulation_resolution(settings):
+    """Return the simulation of the resolution
+
+    Parameters
+    ----------
+    settings : dict
+        settings from project simulation.toml
+
+    Returns
+    -------
+    datetime
+
+    """
+    return timedelta(seconds=settings["Project"]["Step resolution (sec)"])
+
+
 def create_time_range_from_settings(settings):
     """Return the start time, step time, and end time from the settings.
 
@@ -96,9 +128,9 @@ def create_time_range_from_settings(settings):
         (start, end, step)
 
     """
-    start_time = datetime.strptime(settings['Project']["Start time"], DATE_FORMAT)
+    start_time = get_start_time(settings)
     end_time = start_time + timedelta(minutes=settings["Project"]["Simulation duration (min)"])
-    step_time = timedelta(seconds=settings['Project']['Step resolution (sec)'])
+    step_time = get_simulation_resolution(settings)
     return start_time, end_time, step_time
 
 

--- a/PyDSS/valiate_settings.py
+++ b/PyDSS/valiate_settings.py
@@ -43,13 +43,6 @@ settings_dict = {
             'Uninterruptible': {'type': bool, 'Options': [True, False]},
             'Helics logging level': {'type': int, 'Options': range(0, 10)},
         },
-        "Logging": {
-            'Logging Level': {'type': str, 'Options': ["DEBUG", "INFO", "WARNING" , "ERROR"]},
-            'Log to external file': {'type': bool, 'Options': [True, False]},
-            'Display on screen': {'type': bool, 'Options': [True, False]},
-            'Clear old log file': {'type': bool, 'Options': [True, False]},
-            'Log time step updates': {'type': bool, 'Options': [True, False]},
-        },
         "MonteCarlo": {
             'Number of Monte Carlo scenarios': {'type': int},
         },
@@ -195,6 +188,7 @@ settings_dict = {
             'Log to external file': {'type': bool, 'Options': [True, False]},
             'Display on screen': {'type': bool, 'Options': [True, False]},
             'Clear old log file': {'type': bool, 'Options': [True, False]},
+            'Log time step updates': {'type': bool, 'Options': [True, False]},
         },
         "MonteCarlo": {
             'Number of Monte Carlo scenarios': {'type': int},

--- a/PyDSS/valiate_settings.py
+++ b/PyDSS/valiate_settings.py
@@ -48,6 +48,7 @@ settings_dict = {
             'Log to external file': {'type': bool, 'Options': [True, False]},
             'Display on screen': {'type': bool, 'Options': [True, False]},
             'Clear old log file': {'type': bool, 'Options': [True, False]},
+            'Log time step updates': {'type': bool, 'Options': [True, False]},
         },
         "MonteCarlo": {
             'Number of Monte Carlo scenarios': {'type': int},

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,3 +22,4 @@ aiohttp
 aiohttp_swagger3==0.4.3
 requests
 pyyaml
+pydantic

--- a/tests/data/custom_exports_project/Scenarios/scenario1/ExportLists/Exports.toml
+++ b/tests/data/custom_exports_project/Scenarios/scenario1/ExportLists/Exports.toml
@@ -137,3 +137,6 @@ sample_interval = 1
 publish = false
 store_values_type = "all"
 limits = [1.02, 1.04]
+limits_filter = "outside"
+limits_b = [1.01, 1.05]
+limits_filter_b = "outside"

--- a/tests/data/pv_reports_project/simulation.toml
+++ b/tests/data/pv_reports_project/simulation.toml
@@ -18,11 +18,11 @@
 "Return Results" = false
 "Use Controller Registry" = true
 [[Project.Scenarios]]
-name = "pf1"
+name = "control_mode"
 post_process_infos = []
 
 [[Project.Scenarios]]
-name = "control_mode"
+name = "pf1"
 post_process_infos = []
 
 # Export Mode- [Str] - Possible options "byClass" and "byElement"

--- a/tests/test_custom_exports.py
+++ b/tests/test_custom_exports.py
@@ -62,20 +62,23 @@ def test_custom_exports(cleanup_project):
     assert "VoltagesMagAng" not in properties
     assert "CurrentsMagAng" not in properties
 
-    node_names = scenario.list_element_names("Nodes", "VoltageMetric")
-    dfs = scenario.get_filtered_dataframes("Nodes", "VoltageMetric")
-    assert len(node_names) == len(dfs)
-    assert sorted(node_names) == sorted(dfs.keys())
-    for i, node_name in enumerate(node_names):
-        column = node_name + "__Voltage"
-        df = dfs[node_name]
-        # TODO: Slight rounding errors make this intermittent.
-        #expected = all_node_voltages[column]
-        #expected = expected[(expected < 1.02) | (expected > 1.04)]
-        #assert len(df[column]) == len(expected)
-        #assert_series_equal(df[column], expected, check_names=False)
-        df2 = scenario.get_dataframe("Nodes", "VoltageMetric", node_name)
-        assert_series_equal(df[column], df2[column], check_names=False)
+    # TODO: This metric no longer stores voltages in a dataframe.
+    # That functionality could be recovered in PyDSS/metrics.py or we could implement this with
+    # a different export property.
+    #node_names = scenario.list_element_names("Nodes", "VoltageMetric")
+    #dfs = scenario.get_filtered_dataframes("Nodes", "VoltageMetric")
+    #assert len(node_names) == len(dfs)
+    #assert sorted(node_names) == sorted(dfs.keys())
+    #for i, node_name in enumerate(node_names):
+    #    column = node_name + "__Voltage"
+    #    df = dfs[node_name]
+    #    # TODO: Slight rounding errors make this intermittent.
+    #    #expected = all_node_voltages[column]
+    #    #expected = expected[(expected < 1.02) | (expected > 1.04)]
+    #    #assert len(df[column]) == len(expected)
+    #    #assert_series_equal(df[column], expected, check_names=False)
+    #    df2 = scenario.get_dataframe("Nodes", "VoltageMetric", node_name)
+    #    assert_series_equal(df[column], df2[column], check_names=False)
 
     ## Two types of sums are stored.
     normal_amps_sum = scenario.get_element_property_value("Lines", "NormalAmpsSum", "Line.pvl_110")
@@ -153,6 +156,8 @@ def _get_all_node_voltages():
         "Nodes": {
             "VoltageMetric": {
                 "store_values_type": "all",
+                "limits": [1.02, 1.04],
+                "limits_b": [1.01, 1.05],
             },
         }
     }
@@ -162,4 +167,3 @@ def _get_all_node_voltages():
     results = PyDssResults(path)
     assert len(results.scenarios) == 1
     scenario = results.scenarios[0]
-    return scenario.get_full_dataframe("Nodes", "VoltageMetric")


### PR DESCRIPTION
The old method stored any node voltage violation in the HDF5 file. This caused storage sizes to explode when there were lots of violations.